### PR TITLE
upgrade xregexp to 4.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var XRegExp = require('xregexp').XRegExp;
+var XRegExp = require('xregexp');
 var hashtagExp = XRegExp('#[\\p{L}\\d]+', 'i');
 
 function FindHashtags() {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "tape": "~1.0.4"
   },
   "dependencies": {
-    "xregexp": "~2.0.0"
+    "xregexp": "~4.0.0"
   }
 }


### PR DESCRIPTION
by upgrading xregexp to latest version (presently 4.0.0), the overall performance can be remarkably enhanced. e.g., giving  content `var content = 'This #text contains a number of #useful hashtags';`, 
the time of finding hashtags in old version (v2.0.0) takes 26.679ms in my local env,  while it takes only 0.867ms  after the version upgrading (v4.0.0).  this makes a huge performance enhancement in my script in which I need to pluck out hashtags from 1,000,000,000 records.